### PR TITLE
Fix the 'open a suggestion' link in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -8,7 +8,7 @@ ALWAYS create a new branch with your proposed changes. Thank you!
 
 ## Adding an new Item
 
-- Try to fit your item into an existing sections. [Open a suggestion](https://github.com/YOUR_GITHUB_USER/YOUR_REPO/issues/new) to start as discussion about any new sections.
+- Try to fit your item into an existing sections. [Open a suggestion](https://github.com/damian-developer/awesome-filamentphp/issues/new?template=suggestion.yaml) to start as discussion about any new sections.
 - Add a new item to the bottom of the list in a section.
 - If a duplicate item exists, discuss why the new item should replace it.
 - Check your spelling & grammar.


### PR DESCRIPTION
It was `https://github.com/YOUR_GITHUB_USER/YOUR_REPO/issues/new` and I pointed it to https://github.com/damian-developer/awesome-filamentphp/issues/new?template=suggestion.yaml.